### PR TITLE
プレイリスト一覧画面の作成

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,8 @@
 				"mhutchie.git-graph",
 				"eamodio.gitlens",
 				"GitHub.copilot",
-				"GitHub.copilot-chat"
+				"GitHub.copilot-chat",
+				"GitHub.vscode-pull-request-github"
 			]
 		}
 	}

--- a/Gemfile
+++ b/Gemfile
@@ -76,5 +76,6 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
+  gem 'rails-controller-testing'
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,10 @@ GEM
       activesupport (= 7.1.3)
       bundler (>= 1.15.0)
       railties (= 7.1.3)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -337,6 +341,7 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   puma (>= 5.0)
   rails (~> 7.1.3)
+  rails-controller-testing
   redis
   rspec-rails
   rubocop

--- a/app/api_clients/spotify/v1_api_client.rb
+++ b/app/api_clients/spotify/v1_api_client.rb
@@ -19,6 +19,15 @@ module Spotify
       get 'me', headers:
     end
 
+    # GET https://api.spotify.com/v1/me/playlists
+    #
+    # @return [Sawyer::Resource] a list of the playlists owned or followed by the current user
+    # @raise [MyApiClient::Error]
+    # @see https://developer.spotify.com/documentation/web-api/reference/get-a-list-of-current-users-playlists
+    def my_playlists
+      get 'me/playlists', headers:
+    end
+
     private
 
     attr_reader :access_token

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,16 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  class NotLoggedIn < StandardError; end
+
+  rescue_from NotLoggedIn do
+    redirect_to login_path
+  end
+
+  # @return [User] 現在ログイン中のユーザ
+  def current_user
+    User.find_by!(identifier: session[:user_identifier])
+  rescue ActiveRecord::RecordNotFound
+    raise NotLoggedIn
+  end
 end

--- a/app/controllers/authorize_controller.rb
+++ b/app/controllers/authorize_controller.rb
@@ -29,6 +29,8 @@ class AuthorizeController < ApplicationController
       access_token: credentials.access_token,
       refresh_token: credentials.refresh_token
     )
+
+    redirect_to playlists_path
   end
 
   private

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PlaylistsController < ApplicationController
+  def index
+    user_api_client = Spotify::V1ApiClient.new(access_token: current_user.access_token)
+    response = user_api_client.my_playlists
+    @playlists = response['items']
+  end
+end

--- a/app/helpers/playlists_helper.rb
+++ b/app/helpers/playlists_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module PlaylistsHelper
+end

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,0 +1,11 @@
+<h1>Playlists</h1>
+
+<% @playlists.each do |playlist| %>
+  <%= image_tag playlist.images[0].url %>
+  <ul>
+    <li>ID: <%= playlist.id %></li>
+    <li>Name: <%= playlist.name %></li>
+    <li>Track number:<%= playlist.tracks.total %></li>
+    <li>Owner: <%= playlist.owner.display_name || playlist.owner.id %></li>
+  </ul>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resource :login, only: :show
+  resources :playlists, only: :index
+
   get 'authorize/start'
   get 'authorize/callback'
 

--- a/spec/api_clients/spotify/v1_api_client_spec.rb
+++ b/spec/api_clients/spotify/v1_api_client_spec.rb
@@ -41,4 +41,16 @@ RSpec.describe Spotify::V1ApiClient, type: :api_client do
         .with(headers:)
     end
   end
+
+  describe '#my_playlists' do
+    subject(:api_request) { api_client.my_playlists }
+
+    it_behaves_like 'to handle errors'
+
+    it do
+      expect { api_request }
+        .to request_to(:get, 'https://api.spotify.com/v1/me/playlists')
+        .with(headers:)
+    end
+  end
 end

--- a/spec/helpers/playlists_helper_spec.rb
+++ b/spec/helpers/playlists_helper_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PlaylistHelper. For example:
+#
+# describe PlaylistHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PlaylistsHelper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Application' do
+  subject(:api_request) { get test_path }
+
+  let(:mock_controller) do
+    Class.new ApplicationController do
+      def index
+        current_user
+        render status: :ok, plain: 'ok'
+      end
+    end
+  end
+
+  before do
+    stub_const('TestController', mock_controller)
+    # ルーティングの上書き
+    Rails.application.routes.disable_clear_and_finalize = true
+    Rails.application.routes.draw do
+      get 'test', to: 'test#index'
+    end
+    Rails.application.routes.disable_clear_and_finalize = false
+  end
+
+  after do
+    # ルーティングを元に戻す
+    Rails.application.reload_routes!
+  end
+
+  context 'when the user is not logged in' do
+    it 'redirects to the login page' do
+      expect(api_request).to redirect_to(login_path)
+    end
+  end
+
+  context 'when the user is logged in' do
+    before do
+      create(:user, identifier: 'identifier')
+      allow_any_instance_of(TestController).to receive(:session).and_return(user_identifier: 'identifier') # rubocop:disable RSpec/AnyInstance
+    end
+
+    it 'returns 200' do
+      api_request
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/authorize/callback_spec.rb
+++ b/spec/requests/authorize/callback_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe 'Authorizes' do
       expect(v1_api_client).to have_received(:me)
     end
 
+    it 'redirects to the playlists page' do
+      expect(api_request).to redirect_to(playlists_path)
+    end
+
     context 'when the user does not exist' do
       it 'creates a user' do
         expect { api_request }.to change(User, :count).by(1)

--- a/spec/requests/playlists/index_spec.rb
+++ b/spec/requests/playlists/index_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Playlists' do
+  describe 'GET /playlists' do
+    subject(:api_request) { get '/playlists' }
+
+    let(:user) { create(:user) }
+    let(:v1_api_client) { stub_api_client(Spotify::V1ApiClient, my_playlists: { 'items' => [] }) }
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user) # rubocop:disable RSpec/AnyInstance
+      allow(Spotify::V1ApiClient).to receive(:new).and_return(v1_api_client)
+    end
+
+    it 'returns http success' do
+      api_request
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:index)
+    end
+
+    it 'requests user playlists' do
+      api_request
+      expect(v1_api_client).to have_received(:my_playlists)
+    end
+  end
+end

--- a/spec/views/playlists/index.html.erb_spec.rb
+++ b/spec/views/playlists/index.html.erb_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'playlists/index.html.erb' do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
プレイリスト一覧ページでは現在ログインしているユーザのプレイリストが表示される。
see: https://developer.spotify.com/documentation/web-api/reference/get-a-list-of-current-users-playlists

Spotify ログイン後にプレイリスト一覧画面へリダイレクトするようにした。

またログインしていない場合はログインページへリダイレクトするようにした。