### PR TITLE
アクセストークンが期限切れの場合にリフレッシュする

### DIFF
--- a/app/api_clients/spotify/token_api_client.rb
+++ b/app/api_clients/spotify/token_api_client.rb
@@ -23,6 +23,21 @@ module Spotify
       post 'token', body:, headers:
     end
 
+    # Request the refreshing access token
+    # POST https://accounts.spotify.com/api/token
+    #
+    # @param refresh_token [String] Spotify refresh token
+    # @return [Sawyer::Resource]
+    # @raise [MyApiClient::Error]
+    # @see https://developer.spotify.com/documentation/web-api/tutorials/refreshing-tokens
+    def refresh(refresh_token:)
+      body = {
+        grant_type: 'refresh_token',
+        refresh_token:
+      }.to_query
+      post 'token', body:, headers:
+    end
+
     private
 
     def headers

--- a/app/controllers/authorize_controller.rb
+++ b/app/controllers/authorize_controller.rb
@@ -27,7 +27,8 @@ class AuthorizeController < ApplicationController
 
     user.update!(
       access_token: credentials.access_token,
-      refresh_token: credentials.refresh_token
+      refresh_token: credentials.refresh_token,
+      expires_at: credentials.expires_in.seconds.from_now
     )
 
     redirect_to playlists_path

--- a/app/controllers/authorize_controller.rb
+++ b/app/controllers/authorize_controller.rb
@@ -78,7 +78,7 @@ class AuthorizeController < ApplicationController
   end
 
   def fetch_user_info(credentials)
-    user_api_client = Spotify::V1ApiClient.new(access_token: credentials.access_token)
+    user_api_client = Spotify::V1ApiClient.new(user: nil, access_token: credentials.access_token)
     user_api_client.me
   end
 end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -2,7 +2,7 @@
 
 class PlaylistsController < ApplicationController
   def index
-    user_api_client = Spotify::V1ApiClient.new(access_token: current_user.access_token)
+    user_api_client = Spotify::V1ApiClient.new(user: current_user)
     response = user_api_client.my_playlists
     @playlists = response['items']
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@
 #  identifier    :string(255)      not null
 #  access_token  :string(255)      not null
 #  refresh_token :string(255)      not null
+#  expires_at    :datetime
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/db/migrate/20240225004153_add_expires_at_on_users.rb
+++ b/db/migrate/20240225004153_add_expires_at_on_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddExpiresAtOnUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :expires_at, :datetime, after: :refresh_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,11 +12,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_212_011_949) do
+ActiveRecord::Schema[7.1].define(version: 20_240_225_004_153) do
   create_table 'users', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string 'identifier', null: false
     t.string 'access_token', null: false
     t.string 'refresh_token', null: false
+    t.datetime 'expires_at'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
     t.index ['identifier'], name: 'index_users_on_identifier', unique: true

--- a/spec/api_clients/spotify/token_api_client_spec.rb
+++ b/spec/api_clients/spotify/token_api_client_spec.rb
@@ -55,4 +55,24 @@ RSpec.describe Spotify::TokenApiClient, type: :api_client do
         .with(headers:, body: expected_body)
     end
   end
+
+  describe '#refresh' do
+    subject(:api_request) { api_client.refresh(refresh_token:) }
+
+    let(:refresh_token) { 'refresh_token' }
+    let(:expected_body) do
+      {
+        grant_type: 'refresh_token',
+        refresh_token:
+      }.to_query
+    end
+
+    it_behaves_like 'to handle errors'
+
+    it do
+      expect { api_request }
+        .to request_to(:post, 'https://accounts.spotify.com/api/token')
+        .with(headers:, body: expected_body)
+    end
+  end
 end

--- a/spec/api_clients/spotify/v1_api_client_spec.rb
+++ b/spec/api_clients/spotify/v1_api_client_spec.rb
@@ -3,14 +3,25 @@
 require 'rails_helper'
 
 RSpec.describe Spotify::V1ApiClient, type: :api_client do
-  let(:api_client) { described_class.new(access_token:) }
+  let(:api_client) { described_class.new(user:, access_token:) }
+  let(:user) do
+    create(
+      :user,
+      access_token:,
+      refresh_token: 'refresh_token',
+      expires_at:
+    )
+  end
   let(:access_token) { 'access_token' }
+  let(:expires_at) { 1.hour.from_now }
   let(:headers) do
     {
       'Content-Type': 'application/json',
       Authorization: "Bearer #{access_token}"
     }
   end
+
+  before { freeze_time }
 
   shared_examples 'to handle errors' do
     context 'when the API returns 200 OK' do
@@ -26,6 +37,57 @@ RSpec.describe Spotify::V1ApiClient, type: :api_client do
         expect { api_request }
           .to be_handled_as_an_error(MyApiClient::ClientError::BadRequest)
           .when_receive(status_code: 400)
+      end
+    end
+  end
+
+  describe '#initialize' do
+    let(:token_api_client) { stub_api_client(Spotify::TokenApiClient, refresh: credentials) }
+    let(:credentials) do
+      {
+        access_token: 'new_access_token',
+        refresh_token: 'new_refresh_token',
+        expires_in: 3600
+      }
+    end
+
+    before do
+      allow(Spotify::TokenApiClient).to receive(:new).and_return(token_api_client)
+    end
+
+    context 'when the user is not given' do
+      let(:user) { nil }
+
+      it 'does not refresh the access token' do
+        api_client
+        expect(token_api_client).not_to have_received(:refresh)
+      end
+    end
+
+    context 'when the user is given' do
+      context 'when the access token is expired' do
+        let(:expires_at) { 1.hour.ago }
+
+        it 'refreshes the access token' do
+          api_client
+          expect(token_api_client).to have_received(:refresh).with(refresh_token: 'refresh_token')
+        end
+
+        it 'updates the user' do
+          api_client
+          expect(user.reload).to have_attributes(
+            access_token: 'new_access_token',
+            refresh_token: 'new_refresh_token',
+            expires_at: 3600.seconds.from_now
+          )
+        end
+      end
+
+      context 'when the access token is not expired' do
+        it 'does not refresh the access token' do
+          api_client
+          expect(token_api_client).not_to have_received(:refresh)
+        end
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,6 +67,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
 
   config.after do
     Redis.new(url: 'redis://redis:6379/1').flushdb

--- a/spec/requests/authorize/callback_spec.rb
+++ b/spec/requests/authorize/callback_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe 'Authorizes' do
 
     let(:params) { { code: 'code', state: 'state' } }
     let(:token_api_client) { stub_api_client(Spotify::TokenApiClient, token: credentials) }
-    let(:credentials) { { access_token: 'access_token', refresh_token: 'refresh_token' } }
+    let(:credentials) { { access_token: 'access_token', refresh_token: 'refresh_token', expires_in: 3600 } }
     let(:v1_api_client) { stub_api_client(Spotify::V1ApiClient, me: { id: 'identifier' }) }
     let(:session) { { state: 'state' } }
 
     before do
+      freeze_time
+
       allow(Spotify::TokenApiClient).to receive(:new).and_return(token_api_client)
       allow(Spotify::V1ApiClient).to receive(:new).and_return(v1_api_client)
       allow_any_instance_of(AuthorizeController).to receive(:session).and_return(session) # rubocop:disable RSpec/AnyInstance
@@ -43,7 +45,8 @@ RSpec.describe 'Authorizes' do
         expect(user).to have_attributes(
           identifier: 'identifier',
           access_token: 'access_token',
-          refresh_token: 'refresh_token'
+          refresh_token: 'refresh_token',
+          expires_at: 3600.seconds.from_now
         )
       end
 
@@ -73,7 +76,8 @@ RSpec.describe 'Authorizes' do
         expect(user).to have_attributes(
           identifier: 'identifier',
           access_token: 'access_token',
-          refresh_token: 'refresh_token'
+          refresh_token: 'refresh_token',
+          expires_at: 3600.seconds.from_now
         )
       end
 


### PR DESCRIPTION
User モデルに `expires_at` カラムを追加。
有効期限が切れていた場合はトークンをリフレッシュする。