### PR TITLE
プレイリスト詳細画面の作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ Style/Documentation:
 Metrics/BlockLength:
   Exclude:
     - "config/**/*"
+    - "db/**/*"
 
 Metrics/MethodLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -78,4 +78,5 @@ group :test do
   gem 'capybara'
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'
+  gem 'shoulda-matchers'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]
   gem 'factory_bot_rails'
+  gem 'faker'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoulda-matchers (6.1.0)
+      activesupport (>= 5.2.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -350,6 +352,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-thread_safety
   selenium-webdriver
+  shoulda-matchers
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
+    faker (3.2.3)
+      i18n (>= 1.8.11, < 2)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
@@ -337,6 +339,7 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  faker
   importmap-rails
   jbuilder
   my_api_client

--- a/app/api_clients/spotify/v1_api_client.rb
+++ b/app/api_clients/spotify/v1_api_client.rb
@@ -36,6 +36,17 @@ module Spotify
       get 'me/playlists', headers:
     end
 
+    # GET https://api.spotify.com/v1/playlists/#{playlist_id}/tracks
+    #
+    # @param playlist_id [String] The Spotify ID for the playlist.
+    # @return [Sawyer::Resource] Get full details of the items of a playlist owned by a Spotify user.
+    # @raise [MyApiClient::Error]
+    # @see https://developer.spotify.com/documentation/web-api/reference/get-playlists-tracks
+    def playlist_details(playlist_id:)
+      query = { limit: 50 }
+      get "/playlists/#{playlist_id}/tracks", query:, headers:
+    end
+
     private
 
     attr_reader :user, :access_token, :refresh_token, :expires_at

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -5,6 +5,7 @@ class PlaylistsController < ApplicationController
   def index
     response = user_api_client.my_playlists
     @playlists = response['items']
+    save_playlists(@playlists)
   end
 
   # GET /playlists/:identifier
@@ -17,5 +18,17 @@ class PlaylistsController < ApplicationController
 
   def user_api_client
     Spotify::V1ApiClient.new(user: current_user)
+  end
+
+  def save_playlists(playlists)
+    playlists.each do |playlist|
+      current_user
+        .playlists
+        .find_or_initialize_by(identifier: playlist.id)
+        .update!(
+          name: playlist.name,
+          image_url: playlist.images.first&.url
+        )
+    end
   end
 end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
 class PlaylistsController < ApplicationController
+  # GET /playlists
   def index
-    user_api_client = Spotify::V1ApiClient.new(user: current_user)
     response = user_api_client.my_playlists
     @playlists = response['items']
+  end
+
+  # GET /playlists/:identifier
+  def show
+    response = user_api_client.playlist_details(playlist_id: params[:identifier])
+    @playlist_items = response['items']
+  end
+
+  private
+
+  def user_api_client
+    Spotify::V1ApiClient.new(user: current_user)
   end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: artists
+#
+#  id         :bigint           not null, primary key
+#  identifier :string(255)      not null
+#  name       :string(255)      not null
+#  genres     :json
+#  popularity :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_artists_on_identifier  (identifier) UNIQUE
+#
+class Artist < ApplicationRecord
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -17,4 +17,5 @@
 #  index_artists_on_identifier  (identifier) UNIQUE
 #
 class Artist < ApplicationRecord
+  has_many :tracks, dependent: :destroy
 end

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: playlists
+#
+#  id         :bigint           not null, primary key
+#  user_id    :bigint           not null
+#  identifier :string(255)      not null
+#  name       :string(255)
+#  image_url  :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_playlists_on_user_id  (user_id)
+#
+class Playlist < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -18,4 +18,5 @@
 #
 class Playlist < ApplicationRecord
   belongs_to :user
+  has_many :playlist_tracks, dependent: :destroy
 end

--- a/app/models/playlist_track.rb
+++ b/app/models/playlist_track.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: playlist_tracks
+#
+#  id          :bigint           not null, primary key
+#  playlist_id :bigint           not null
+#  track_id    :bigint           not null
+#  position    :integer          default(0), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_playlist_tracks_on_playlist_id_and_track_id  (playlist_id,track_id) UNIQUE
+#
+class PlaylistTrack < ApplicationRecord
+  belongs_to :playlist
+  belongs_to :track
+end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: tracks
+#
+#  id          :bigint           not null, primary key
+#  artist_id   :bigint           not null
+#  identifier  :string(255)      not null
+#  popularity  :integer          not null
+#  duration_ms :integer          not null
+#  name        :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_tracks_on_artist_id   (artist_id)
+#  index_tracks_on_identifier  (identifier) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (artist_id => artists.id)
+#
+class Track < ApplicationRecord
+  belongs_to :artist
+end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -24,4 +24,5 @@
 #
 class Track < ApplicationRecord
   belongs_to :artist
+  has_many :playlist_tracks, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,5 @@
 #  index_users_on_identifier  (identifier) UNIQUE
 #
 class User < ApplicationRecord
+  has_many :playlists, dependent: :destroy
 end

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -7,5 +7,6 @@
     <li>Name: <%= playlist.name %></li>
     <li>Track number:<%= playlist.tracks.total %></li>
     <li>Owner: <%= playlist.owner.display_name || playlist.owner.id %></li>
+    <%= link_to 'details', playlist_path(playlist.id) %>
   </ul>
 <% end %>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -1,0 +1,9 @@
+<h1>Playlist Details</h1>
+
+<% @playlist_items.each do |item| %>
+  <%= image_tag item.track.album.images[0].url %>
+  <ul>
+    <li>Name: <%= item.track.name %></li>
+    <li>Artist: <%= item.track.artists.map(&:name).join(',') %></li>
+  </ul>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resource :login, only: :show
-  resources :playlists, only: :index
+  resources :playlists, only: %i[index show], param: :identifier
 
   get 'authorize/start'
   get 'authorize/callback'

--- a/db/migrate/20240303115756_create_playlist.rb
+++ b/db/migrate/20240303115756_create_playlist.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreatePlaylist < ActiveRecord::Migration[7.1]
+  def change
+    create_table :playlists do |t|
+      t.references :user, null: false
+      t.string :identifier, null: false
+      t.string :name
+      t.string :image_url
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240306101746_create_artist.rb
+++ b/db/migrate/20240306101746_create_artist.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateArtist < ActiveRecord::Migration[7.1]
+  def change
+    create_table :artists do |t|
+      t.string :identifier, null: false
+      t.string :name, null: false
+      t.json :genres
+      t.integer :popularity
+      t.timestamps
+
+      t.index :identifier, unique: true
+    end
+  end
+end

--- a/db/migrate/20240306113348_create_tracks.rb
+++ b/db/migrate/20240306113348_create_tracks.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateTracks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tracks do |t|
+      t.references :artist, null: false, foreign_key: true
+      t.string :identifier, null: false
+      t.integer :popularity, null: false
+      t.integer :duration_ms, null: false
+      t.string :name
+      t.timestamps
+
+      t.index :identifier, unique: true
+    end
+  end
+end

--- a/db/migrate/20240309095847_create_playlist_track.rb
+++ b/db/migrate/20240309095847_create_playlist_track.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreatePlaylistTrack < ActiveRecord::Migration[7.1]
+  def change
+    create_table :playlist_tracks do |t|
+      t.references :playlist, null: false, index: false
+      t.references :track, null: false, index: false
+      t.integer :position, null: false, default: 0
+
+      t.timestamps
+
+      t.index %i[playlist_id track_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_225_004_153) do
+ActiveRecord::Schema[7.1].define(version: 20_240_303_115_756) do
+  create_table 'playlists', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.string 'identifier', null: false
+    t.string 'name'
+    t.string 'image_url'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_playlists_on_user_id'
+  end
+
   create_table 'users', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string 'identifier', null: false
     t.string 'access_token', null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_306_113_348) do
+ActiveRecord::Schema[7.1].define(version: 20_240_309_095_847) do
   create_table 'artists', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string 'identifier', null: false
     t.string 'name', null: false
@@ -21,6 +21,15 @@ ActiveRecord::Schema[7.1].define(version: 20_240_306_113_348) do
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
     t.index ['identifier'], name: 'index_artists_on_identifier', unique: true
+  end
+
+  create_table 'playlist_tracks', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
+    t.bigint 'playlist_id', null: false
+    t.bigint 'track_id', null: false
+    t.integer 'position', default: 0, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index %w[playlist_id track_id], name: 'index_playlist_tracks_on_playlist_id_and_track_id', unique: true
   end
 
   create_table 'playlists', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_306_101_746) do
+ActiveRecord::Schema[7.1].define(version: 20_240_306_113_348) do
   create_table 'artists', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string 'identifier', null: false
     t.string 'name', null: false
@@ -33,6 +33,18 @@ ActiveRecord::Schema[7.1].define(version: 20_240_306_101_746) do
     t.index ['user_id'], name: 'index_playlists_on_user_id'
   end
 
+  create_table 'tracks', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
+    t.bigint 'artist_id', null: false
+    t.string 'identifier', null: false
+    t.integer 'popularity', null: false
+    t.integer 'duration_ms', null: false
+    t.string 'name'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['artist_id'], name: 'index_tracks_on_artist_id'
+    t.index ['identifier'], name: 'index_tracks_on_identifier', unique: true
+  end
+
   create_table 'users', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string 'identifier', null: false
     t.string 'access_token', null: false
@@ -42,4 +54,6 @@ ActiveRecord::Schema[7.1].define(version: 20_240_306_101_746) do
     t.datetime 'updated_at', null: false
     t.index ['identifier'], name: 'index_users_on_identifier', unique: true
   end
+
+  add_foreign_key 'tracks', 'artists'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_303_115_756) do
+ActiveRecord::Schema[7.1].define(version: 20_240_306_101_746) do
+  create_table 'artists', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
+    t.string 'identifier', null: false
+    t.string 'name', null: false
+    t.json 'genres'
+    t.integer 'popularity'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['identifier'], name: 'index_artists_on_identifier', unique: true
+  end
+
   create_table 'playlists', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.bigint 'user_id', null: false
     t.string 'identifier', null: false

--- a/spec/api_clients/spotify/v1_api_client_spec.rb
+++ b/spec/api_clients/spotify/v1_api_client_spec.rb
@@ -115,4 +115,19 @@ RSpec.describe Spotify::V1ApiClient, type: :api_client do
         .with(headers:)
     end
   end
+
+  describe '#playlist_details' do
+    subject(:api_request) { api_client.playlist_details(playlist_id:) }
+
+    let(:playlist_id) { 'playlist_id' }
+    let(:query) { { limit: 50 } }
+
+    it_behaves_like 'to handle errors'
+
+    it do
+      expect { api_request }
+        .to request_to(:get, 'https://api.spotify.com/v1/playlists/playlist_id/tracks')
+        .with(headers:, query:)
+    end
+  end
 end

--- a/spec/factories/artists.rb
+++ b/spec/factories/artists.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :artist do
+    identifier { 'identifier' }
+  end
+end

--- a/spec/factories/artists.rb
+++ b/spec/factories/artists.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :artist do
-    identifier { 'identifier' }
+    identifier { Faker::Alphanumeric.alpha(number: 10) }
+    name { Faker::Music::RockBand.name }
   end
 end

--- a/spec/factories/playlist_tracks.rb
+++ b/spec/factories/playlist_tracks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :playlist_track do
+    playlist
+    track
+  end
+end

--- a/spec/factories/playlists.rb
+++ b/spec/factories/playlists.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :playlist do
     user
-    identifier { 'identifier' }
+    identifier { Faker::Alphanumeric.alpha(number: 10) }
   end
 end

--- a/spec/factories/playlists.rb
+++ b/spec/factories/playlists.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :playlist do
+    user
+    identifier { 'identifier' }
+  end
+end

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :track do
+    artist
+    identifier { 'identifier' }
+    popularity { 1 }
+    duration_ms { 1 }
+    name { 'name' }
+  end
+end

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -3,9 +3,9 @@
 FactoryBot.define do
   factory :track do
     artist
-    identifier { 'identifier' }
-    popularity { 1 }
-    duration_ms { 1 }
-    name { 'name' }
+    identifier { Faker::Alphanumeric.alpha(number: 10) }
+    popularity { 100 }
+    duration_ms { 100_000 }
+    name { Faker::Music::RockBand.song }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :user do
-    identifier { 'identifier' }
+    identifier { Faker::Alphanumeric.alpha(number: 10) }
     access_token { 'access_token' }
     refresh_token { 'refresh_token' }
   end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Artist do
+  describe 'associations' do
+    subject(:instance) { build(:artist) }
+
+    it { expect(instance).to have_many(:tracks).dependent(:destroy) }
+  end
+end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-RSpec.describe Track do
+RSpec.describe Playlist do
   describe 'associations' do
-    subject(:instance) { build(:track) }
+    subject(:instance) { build(:playlist) }
 
-    it { expect(instance).to belong_to(:artist) }
+    it { expect(instance).to belong_to(:user) }
     it { expect(instance).to have_many(:playlist_tracks).dependent(:destroy) }
   end
 end

--- a/spec/models/playlist_track_spec.rb
+++ b/spec/models/playlist_track_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PlaylistTrack do
+  describe 'associations' do
+    subject(:instance) { build(:playlist_track) }
+
+    it { expect(instance).to belong_to(:playlist) }
+    it { expect(instance).to belong_to(:track) }
+  end
+end

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Track do
+  describe 'associations' do
+    subject(:instance) { build(:track) }
+
+    it { expect(instance).to belong_to(:artist) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,5 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    subject(:instance) { build(:user) }
+
+    it { expect(instance).to have_many(:playlists).dependent(:destroy) }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,14 @@ begin
 rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [

--- a/spec/requests/playlists/index_spec.rb
+++ b/spec/requests/playlists/index_spec.rb
@@ -7,7 +7,20 @@ RSpec.describe 'Playlists' do
     subject(:api_request) { get '/playlists' }
 
     let(:user) { create(:user) }
-    let(:v1_api_client) { stub_api_client(Spotify::V1ApiClient, my_playlists: { 'items' => [] }) }
+    let(:v1_api_client) { stub_api_client(Spotify::V1ApiClient, my_playlists: playlist_response) }
+    let(:playlist_response) do
+      {
+        items: [
+          {
+            id: 'playlist_identifier',
+            name: 'playlist_name',
+            images: [{ url: 'https://example.png' }],
+            tracks: { total: 1 },
+            owner: { id: 'user_identifier', display_name: 'user_name' }
+          }
+        ]
+      }
+    end
 
     before do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user) # rubocop:disable RSpec/AnyInstance
@@ -23,6 +36,19 @@ RSpec.describe 'Playlists' do
     it 'requests user playlists' do
       api_request
       expect(v1_api_client).to have_received(:my_playlists)
+    end
+
+    it 'saves user playlists' do
+      expect { api_request }.to change(user.playlists, :count).by(1)
+    end
+
+    it 'saves playlist details' do
+      api_request
+      expect(user.playlists.last).to have_attributes(
+        identifier: 'playlist_identifier',
+        name: 'playlist_name',
+        image_url: 'https://example.png'
+      )
     end
   end
 end

--- a/spec/requests/playlists/show_spec.rb
+++ b/spec/requests/playlists/show_spec.rb
@@ -7,8 +7,36 @@ RSpec.describe 'Playlists' do
     subject(:api_request) { get "/playlists/#{playlist_id}" }
 
     let(:user) { create(:user) }
-    let(:playlist_id) { '123' }
-    let(:v1_api_client) { stub_api_client(Spotify::V1ApiClient, playlist_details: { 'items' => [] }) }
+    let(:playlist) { create(:playlist, user:) }
+    let(:playlist_id) { playlist.identifier }
+    let(:v1_api_client) { stub_api_client(Spotify::V1ApiClient, playlist_details: playlist_details_response) }
+    let(:playlist_details_response) do
+      {
+        items: [
+          {
+            track: {
+              id: 'track_identifier_1',
+              name: 'Track 1',
+              popularity: 100,
+              duration_ms: 100_000,
+              album: {
+                images: [
+                  { url: 'http://example.com/image.jpg' }
+                ]
+              },
+              artists: [
+                {
+                  id: 'artist_identifier_1',
+                  name: 'Artist 1',
+                  genres: %w[pop rock],
+                  popularity: 100
+                }
+              ]
+            }
+          }
+        ]
+      }
+    end
 
     before do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user) # rubocop:disable RSpec/AnyInstance
@@ -24,6 +52,44 @@ RSpec.describe 'Playlists' do
     it 'requests playlist details' do
       api_request
       expect(v1_api_client).to have_received(:playlist_details)
+    end
+
+    it 'saves playlist details' do
+      expect { api_request }
+        .to change(PlaylistTrack, :count).by(1)
+        .and change(Track, :count).by(1)
+        .and change(Artist, :count).by(1)
+    end
+
+    it 'persists artist' do
+      api_request
+      artist = Artist.find_by(identifier: 'artist_identifier_1')
+      expect(artist).to have_attributes(
+        name: 'Artist 1',
+        genres: %w[pop rock],
+        popularity: 100
+      )
+    end
+
+    it 'persists track' do
+      api_request
+      track = Track.find_by(identifier: 'track_identifier_1')
+      expect(track).to have_attributes(
+        name: 'Track 1',
+        popularity: 100,
+        duration_ms: 100_000,
+        artist_id: Artist.find_by(identifier: 'artist_identifier_1').id
+      )
+    end
+
+    it 'persists playlist track' do
+      api_request
+      playlist_track = PlaylistTrack.last
+      expect(playlist_track).to have_attributes(
+        playlist_id: playlist.id,
+        track_id: Track.find_by(identifier: 'track_identifier_1').id,
+        position: 0
+      )
     end
   end
 end

--- a/spec/requests/playlists/show_spec.rb
+++ b/spec/requests/playlists/show_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Playlists' do
+  describe 'GET /playlists/:identifier' do
+    subject(:api_request) { get "/playlists/#{playlist_id}" }
+
+    let(:user) { create(:user) }
+    let(:playlist_id) { '123' }
+    let(:v1_api_client) { stub_api_client(Spotify::V1ApiClient, playlist_details: { 'items' => [] }) }
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user) # rubocop:disable RSpec/AnyInstance
+      allow(Spotify::V1ApiClient).to receive(:new).and_return(v1_api_client)
+    end
+
+    it 'returns http success' do
+      api_request
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:show)
+    end
+
+    it 'requests playlist details' do
+      api_request
+      expect(v1_api_client).to have_received(:playlist_details)
+    end
+  end
+end

--- a/spec/views/playlists/show.html.erb_spec.rb
+++ b/spec/views/playlists/show.html.erb_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'playlists/show.html.erb' do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
プレイリスト詳細画面ではプレイリストに保存されている曲の詳細を表示する。  
see: https://developer.spotify.com/documentation/web-api/reference/get-playlists-tracks

一旦ページネーションは見送り、最初の 50 曲のみを取得している。  
今後プレイリストの複製を行うことを見越して、track, artist 情報を DB に保存するようにした。  
いずれ reccomend を行いたいが、その際に album 情報は不要なので、 album は DB に保存していない。