### PR TITLE
プレイリストの複製機能追加

### DIFF
--- a/app/api_clients/spotify/v1_api_client.rb
+++ b/app/api_clients/spotify/v1_api_client.rb
@@ -47,6 +47,17 @@ module Spotify
       get "/playlists/#{playlist_id}/tracks", query:, headers:
     end
 
+    # POST https://api.spotify.com/v1/users/{user_id}/playlists
+    #
+    # @param name [String] The playlist name.
+    # @return [Sawyer::Resource] Get a created playlist.
+    # @raise [MyApiClient::Error]
+    # @see https://developer.spotify.com/documentation/web-api/reference/create-playlist
+    def create_playlist(name:)
+      body = { name: }
+      post "/users/#{user.identifier}/playlists", body:, headers:
+    end
+
     private
 
     attr_reader :user, :access_token, :refresh_token, :expires_at

--- a/app/api_clients/spotify/v1_api_client.rb
+++ b/app/api_clients/spotify/v1_api_client.rb
@@ -58,6 +58,20 @@ module Spotify
       post "/users/#{user.identifier}/playlists", body:, headers:
     end
 
+    # POST https://api.spotify.com/v1/playlists/{playlist_id}/tracks
+    #
+    # @param playlist_identifier [String] The playlist identifier.
+    # @param tracks [Array<Track>] A list of tracks.
+    # @param position [Integer] The position to insert the tracks, a zero-based index.
+    # @return [Sawyer::Resource] A snapshot ID for the playlist.
+    # @raise [MyApiClient::Error]
+    # @see https://developer.spotify.com/documentation/web-api/reference/add-tracks-to-playlist
+    def add_playlist_tracks(playlist_identifier:, tracks:, position: 0)
+      uris = tracks.map { |track| "spotify:track:#{track.identifier}" }
+      body = { position:, uris: }
+      post "/playlists/#{playlist_identifier}/tracks", body:, headers:
+    end
+
     private
 
     attr_reader :user, :access_token, :refresh_token, :expires_at

--- a/app/controllers/authorize_controller.rb
+++ b/app/controllers/authorize_controller.rb
@@ -57,7 +57,7 @@ class AuthorizeController < ApplicationController
   end
 
   def scope
-    'playlist-modify-private'
+    'playlist-modify-private playlist-modify-public'
   end
 
   def redirect_uri

--- a/app/controllers/playlists/duplicate_controller.rb
+++ b/app/controllers/playlists/duplicate_controller.rb
@@ -3,7 +3,9 @@
 module Playlists
   class DuplicateController < ApplicationController
     # GET /playlists/:identifier/duplicate
-    def new; end
+    def new
+      @current_playlist = current_playlist
+    end
 
     # POST /playlists/:identifier/duplicate
     def create

--- a/app/controllers/playlists/duplicate_controller.rb
+++ b/app/controllers/playlists/duplicate_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Playlists
+  class DuplicateController < ApplicationController
+    # GET /playlists/:identifier/duplicate
+    def new; end
+
+    # POST /playlists/:identifier/duplicate
+    def create
+      response = user_api_client.create_playlist(name: params[:name])
+
+      new_playlist = duplicate_playlist(response)
+
+      tracks = current_playlist.playlist_tracks.map(&:track)
+      user_api_client.add_playlist_tracks(playlist_identifier: new_playlist.identifier, tracks:)
+
+      redirect_to playlist_path(new_playlist.identifier)
+    end
+
+    private
+
+    def current_playlist
+      @current_playlist ||= current_user.playlists.find_by!(identifier: params[:playlist_identifier])
+    end
+
+    def user_api_client
+      Spotify::V1ApiClient.new(user: current_user)
+    end
+
+    # @param response [Sawyer::Resource]
+    # @return [Playlist]
+    def duplicate_playlist(response)
+      new_playlist = current_user.playlists.create!(identifier: response['id'], name: response['name'])
+
+      # rubocop:disable Rails/SkipsModelValidations
+      new_playlist.playlist_tracks.insert_all!(
+        current_playlist.playlist_tracks.map { |pt| { track_id: pt.track_id, position: pt.position } }
+      )
+      # rubocop:enable Rails/SkipsModelValidations
+
+      new_playlist
+    end
+  end
+end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -38,13 +38,14 @@ class PlaylistsController < ApplicationController
   end
 
   def save_playlist_details(playlist_items)
+    current_playlist.playlist_tracks.destroy_all
+
     playlist_items.each_with_index do |item, index|
       artist = create_or_find_artist(item)
 
       track = create_or_find_track(item, artist)
 
-      playlist_track = PlaylistTrack.create_or_find_by!(playlist_id: current_playlist.id, track_id: track.id)
-      playlist_track.update!(position: index)
+      current_playlist.playlist_tracks.create!(track:, position: index)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,8 @@
 #
 #  id            :bigint           not null, primary key
 #  identifier    :string(255)      not null
-#  access_token  :string(255)      not null
-#  refresh_token :string(255)      not null
+#  access_token  :string(512)      not null
+#  refresh_token :string(512)      not null
 #  expires_at    :datetime
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null

--- a/app/views/playlists/duplicate/new.html.erb
+++ b/app/views/playlists/duplicate/new.html.erb
@@ -1,0 +1,7 @@
+<h1>Playlist Duplicate</h1>
+
+<%= form_with url: playlist_duplicate_path(@current_playlist.identifier), method: :post do |f| %>
+  <%= f.label :name, "Playlist name:" %>
+  <%= f.text_field :name, value: @current_playlist.name %>
+  <%= f.submit "Duplicate" %>
+<% end %>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -1,9 +1,13 @@
 <h1>Playlist Details</h1>
 
-<% @playlist_items.each do |item| %>
-  <%= image_tag item.track.album.images[0].url %>
-  <ul>
-    <li>Name: <%= item.track.name %></li>
-    <li>Artist: <%= item.track.artists.map(&:name).join(',') %></li>
-  </ul>
-<% end %>
+<%= link_to 'Duplicate', playlist_duplicate_path(@current_playlist.identifier) %>
+
+<div>
+  <% @playlist_items.each do |item| %>
+    <%= image_tag item.track.album.images[0].url %>
+    <ul>
+      <li>Name: <%= item.track.name %></li>
+      <li>Artist: <%= item.track.artists.map(&:name).join(',') %></li>
+    </ul>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,12 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resource :login, only: :show
-  resources :playlists, only: %i[index show], param: :identifier
+  resources :playlists, only: %i[index show], param: :identifier do
+    scope module: :playlists do
+      get :duplicate, to: 'duplicate#new'
+      post :duplicate, to: 'duplicate#create'
+    end
+  end
 
   get 'authorize/start'
   get 'authorize/callback'

--- a/db/migrate/20240317045752_update_token_length_on_user.rb
+++ b/db/migrate/20240317045752_update_token_length_on_user.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class UpdateTokenLengthOnUser < ActiveRecord::Migration[7.1]
+  def up
+    change_table :users, bulk: true do |t|
+      t.change :access_token, :string, limit: 512
+      t.change :refresh_token, :string, limit: 512
+    end
+  end
+
+  def down
+    change_table :users, bulk: true do |t|
+      t.change :access_token, :string, limit: 255
+      t.change :refresh_token, :string, limit: 255
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_309_095_847) do
+ActiveRecord::Schema[7.1].define(version: 20_240_317_045_752) do
   create_table 'artists', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string 'identifier', null: false
     t.string 'name', null: false
@@ -56,8 +56,8 @@ ActiveRecord::Schema[7.1].define(version: 20_240_309_095_847) do
 
   create_table 'users', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string 'identifier', null: false
-    t.string 'access_token', null: false
-    t.string 'refresh_token', null: false
+    t.string 'access_token', limit: 512, null: false
+    t.string 'refresh_token', limit: 512, null: false
     t.datetime 'expires_at'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false

--- a/spec/api_clients/spotify/v1_api_client_spec.rb
+++ b/spec/api_clients/spotify/v1_api_client_spec.rb
@@ -130,4 +130,19 @@ RSpec.describe Spotify::V1ApiClient, type: :api_client do
         .with(headers:, query:)
     end
   end
+
+  describe '#create_playlist' do
+    subject(:api_request) { api_client.create_playlist(name:) }
+
+    let(:name) { 'playlist_name' }
+    let(:expected_body) { { name: 'playlist_name' } }
+
+    it_behaves_like 'to handle errors'
+
+    it do
+      expect { api_request }
+        .to request_to(:post, "https://api.spotify.com/v1/users/#{user.identifier}/playlists")
+        .with(headers:, body: expected_body)
+    end
+  end
 end

--- a/spec/api_clients/spotify/v1_api_client_spec.rb
+++ b/spec/api_clients/spotify/v1_api_client_spec.rb
@@ -145,4 +145,34 @@ RSpec.describe Spotify::V1ApiClient, type: :api_client do
         .with(headers:, body: expected_body)
     end
   end
+
+  describe '#add_playlist_tracks' do
+    subject(:api_request) { api_client.add_playlist_tracks(playlist_identifier:, tracks:, position:) }
+
+    let(:playlist_identifier) { 'playlist_identifier' }
+    let(:tracks) { Track.all }
+    let(:position) { 1 }
+    let(:expected_body) do
+      {
+        uris: [
+          'spotify:track:track_identifier1',
+          'spotify:track:track_identifier2'
+        ],
+        position: 1
+      }
+    end
+
+    before do
+      create(:track, identifier: 'track_identifier1')
+      create(:track, identifier: 'track_identifier2')
+    end
+
+    it_behaves_like 'to handle errors'
+
+    it do
+      expect { api_request }
+        .to request_to(:post, 'https://api.spotify.com/v1/playlists/playlist_identifier/tracks')
+        .with(headers:, body: expected_body)
+    end
+  end
 end

--- a/spec/requests/authorize/start_spec.rb
+++ b/spec/requests/authorize/start_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe 'Authorizes' do
       {
         response_type: 'code',
         client_id: 'spotify-client-id',
-        scope: 'playlist-modify-private',
+        scope: 'playlist-modify-private playlist-modify-public',
         redirect_uri: 'http://localhost:3000/authorize/callback',
         state:
       }
     end
-    let(:expected_url) { "#{authorize_url}?#{query.to_param}" }
+    let(:expected_url) { "#{authorize_url}?#{query.to_param.gsub('+', '%20')}" }
     let(:state) { 'state' }
     let(:session) do
       instance_double(ActionDispatch::Request::Session)

--- a/spec/requests/playlists/duplicate/create_spec.rb
+++ b/spec/requests/playlists/duplicate/create_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Playlists::Duplicate' do
+  describe 'POST /playlists/:identifier/duplicate' do
+    subject(:api_request) { post "/playlists/#{playlist_id}/duplicate", params: { name: 'New Playlist' } }
+
+    let(:user) { create(:user) }
+    let(:playlist) { create(:playlist, user:) }
+    let(:playlist_id) { playlist.identifier }
+    let(:v1_api_client) do
+      stub_api_client(
+        Spotify::V1ApiClient,
+        create_playlist: create_playlist_response,
+        add_playlist_tracks: nil
+      )
+    end
+    let(:create_playlist_response) do
+      {
+        id: 'new_playlist_identifier',
+        name: 'New Playlist'
+      }
+    end
+
+    before do
+      create_list(:playlist_track, 3, playlist:)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user) # rubocop:disable RSpec/AnyInstance
+      allow(Spotify::V1ApiClient).to receive(:new).and_return(v1_api_client)
+    end
+
+    context 'when a normal case' do
+      it 'redirects to the playlists page' do
+        expect(api_request).to redirect_to(playlist_path('new_playlist_identifier'))
+      end
+
+      it 'creates a new playlist' do
+        expect { api_request }
+          .to change(Playlist, :count).by(1)
+          .and change(PlaylistTrack, :count).by(playlist.playlist_tracks.count)
+      end
+
+      it 'requests playlist creation' do
+        api_request
+        expect(v1_api_client)
+          .to have_received(:create_playlist)
+          .with(name: 'New Playlist')
+      end
+
+      it 'requests playlist tracks addition' do
+        api_request
+        expect(v1_api_client)
+          .to have_received(:add_playlist_tracks)
+          .with(playlist_identifier: 'new_playlist_identifier', tracks: playlist.playlist_tracks.map(&:track))
+      end
+    end
+  end
+end


### PR DESCRIPTION
プレイリスト名を指定して、既存のプレイリストを複製する。  

新規にプレイリストを作成し、同じ track を追加する。  
public のプレイリストを作成するので `playlist-modify-public` のスコープを追加する。  
スコープを追加したことによりアクセストークンの長さが変わったので、DBの length を変更した。