### PR TITLE
プレイリスト詳細画面を API のレスポンスではなくレコードから組み立てる

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -63,10 +63,11 @@ class PlaylistsController < ApplicationController
   def create_or_find_track(item, artist)
     track = item.track
     Track.create_or_find_by!(identifier: track.id) do |t|
-      t.artist_id = artist.id
+      t.artist = artist
       t.popularity = track.popularity
       t.duration_ms = track.duration_ms
       t.name = track.name
+      t.image_url = track.album.images.first&.url
     end
   end
 end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -11,8 +11,8 @@ class PlaylistsController < ApplicationController
   # GET /playlists/:identifier
   def show
     response = user_api_client.playlist_details(playlist_id: current_playlist.identifier)
-    @playlist_items = response['items']
-    save_playlist_details(@playlist_items)
+    playlist_items = response['items']
+    save_playlist_details(playlist_items)
   end
 
   private

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -18,5 +18,7 @@
 #
 class Playlist < ApplicationRecord
   belongs_to :user
+
   has_many :playlist_tracks, dependent: :destroy
+  has_many :tracks, through: :playlist_tracks
 end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -25,5 +25,7 @@
 #
 class Track < ApplicationRecord
   belongs_to :artist
+
   has_many :playlist_tracks, dependent: :destroy
+  has_many :playlist, through: :playlist_tracks
 end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -10,6 +10,7 @@
 #  popularity  :integer          not null
 #  duration_ms :integer          not null
 #  name        :string(255)
+#  image_url   :string(255)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -3,11 +3,11 @@
 <%= link_to 'Duplicate', playlist_duplicate_path(@current_playlist.identifier) %>
 
 <div>
-  <% @playlist_items.each do |item| %>
-    <%= image_tag item.track.album.images[0].url %>
+  <% @current_playlist.tracks.each do |track| %>
+    <%= image_tag track.image_url %>
     <ul>
-      <li>Name: <%= item.track.name %></li>
-      <li>Artist: <%= item.track.artists.map(&:name).join(',') %></li>
+      <li>Name: <%= track.name %></li>
+      <li>Artist: <%= track.artist.name %></li>
     </ul>
   <% end %>
 </div>

--- a/db/migrate/20240323024011_add_image_url_on_track.rb
+++ b/db/migrate/20240323024011_add_image_url_on_track.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddImageUrlOnTrack < ActiveRecord::Migration[7.1]
+  def change
+    add_column :tracks, :image_url, :string, after: :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_317_045_752) do
+ActiveRecord::Schema[7.1].define(version: 20_240_323_024_011) do
   create_table 'artists', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string 'identifier', null: false
     t.string 'name', null: false
@@ -48,6 +48,7 @@ ActiveRecord::Schema[7.1].define(version: 20_240_317_045_752) do
     t.integer 'popularity', null: false
     t.integer 'duration_ms', null: false
     t.string 'name'
+    t.string 'image_url'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
     t.index ['artist_id'], name: 'index_tracks_on_artist_id'

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe Playlist do
 
     it { expect(instance).to belong_to(:user) }
     it { expect(instance).to have_many(:playlist_tracks).dependent(:destroy) }
+    it { expect(instance).to have_many(:tracks).through(:playlist_tracks) }
   end
 end

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe Track do
 
     it { expect(instance).to belong_to(:artist) }
     it { expect(instance).to have_many(:playlist_tracks).dependent(:destroy) }
+    it { expect(instance).to have_many(:playlists).through(:playlist_tracks) }
   end
 end

--- a/spec/requests/playlists/show_spec.rb
+++ b/spec/requests/playlists/show_spec.rb
@@ -75,10 +75,11 @@ RSpec.describe 'Playlists' do
       api_request
       track = Track.find_by(identifier: 'track_identifier_1')
       expect(track).to have_attributes(
+        artist: Artist.find_by(identifier: 'artist_identifier_1'),
         name: 'Track 1',
         popularity: 100,
         duration_ms: 100_000,
-        artist_id: Artist.find_by(identifier: 'artist_identifier_1').id
+        image_url: 'http://example.com/image.jpg'
       )
     end
 


### PR DESCRIPTION
track の画像を保存していなかったので、一時的に API のレスポンスから画面を構築していた。  
track に image_url のカラムを追加し、レコードから画面を構築するようにする。  

いずれ Active Storage に画像を保存しても良さそうだが、一旦 image_url を保存する。